### PR TITLE
bugfix: ширина контейнера при больших разрешениях стала 100%

### DIFF
--- a/blocks/container/container.css
+++ b/blocks/container/container.css
@@ -1,5 +1,6 @@
 .container {
   max-width: 1360px;
+  width: 100%;
 }
 
 @media screen and (max-width: 1440px) {


### PR DESCRIPTION
поможет в случае , если содержимое контейнера не занимает всю доступную ширину. 